### PR TITLE
feat: 일정 생성 및 조회 기능 구현

### DIFF
--- a/src/main/java/com/doorcs/schedule/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/doorcs/schedule/controller/GlobalExceptionHandler.java
@@ -1,9 +1,12 @@
 package com.doorcs.schedule.controller;
 
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import com.doorcs.schedule.exception.BadRequestException;
 import com.doorcs.schedule.exception.NotFoundException;
@@ -13,6 +16,20 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(EmptyResultDataAccessException.class)
+    public ProblemDetail handleEmptyResultDataAccessException(EmptyResultDataAccessException e) {
+        log.warn("[Empty Result]", e);
+
+        return ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다.");
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ProblemDetail handleNoResourceFoundException(NoResourceFoundException e) {
+        log.warn("[No Resource]", e);
+
+        return ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다.");
+    }
 
     @ExceptionHandler(BadRequestException.class)
     public ProblemDetail handleBadRequestException(BadRequestException e) {
@@ -26,6 +43,13 @@ public class GlobalExceptionHandler {
         log.warn("[Not Found]", e);
 
         return ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다.");
+    }
+
+    @ExceptionHandler(DataAccessException.class)
+    public ProblemDetail handleDataAccessException(DataAccessException e) {
+        log.error("[JDBC Error]", e);
+
+        return ProblemDetail.forStatusAndDetail(HttpStatus.INTERNAL_SERVER_ERROR, "데이터베이스 오류가 발생했습니다.");
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/doorcs/schedule/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/doorcs/schedule/controller/GlobalExceptionHandler.java
@@ -1,0 +1,38 @@
+package com.doorcs.schedule.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.doorcs.schedule.exception.BadRequestException;
+import com.doorcs.schedule.exception.NotFoundException;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BadRequestException.class)
+    public ProblemDetail handleBadRequestException(BadRequestException e) {
+        log.warn("[Bad Request]", e);
+
+        return ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, "잘못된 요청입니다.");
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    public ProblemDetail handleNotFoundException(NotFoundException e) {
+        log.warn("[Not Found]", e);
+
+        return ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다.");
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ProblemDetail handleException(Exception e) {
+
+        log.error("[Internal Server Error]", e);
+
+        return ProblemDetail.forStatusAndDetail(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다.");
+    }
+}

--- a/src/main/java/com/doorcs/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/doorcs/schedule/controller/ScheduleController.java
@@ -1,14 +1,21 @@
 package com.doorcs.schedule.controller;
 
+import java.sql.Date;
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.doorcs.schedule.service.ScheduleService;
 import com.doorcs.schedule.service.request.CreateScheduleRequest;
 import com.doorcs.schedule.service.response.CreateScheduleResponse;
+import com.doorcs.schedule.service.response.ReadScheduleResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -26,5 +33,24 @@ public class ScheduleController {
         CreateScheduleResponse createScheduleResponse = scheduleService.create(createScheduleRequest);
 
         return ResponseEntity.ok().body(createScheduleResponse);
+    }
+
+    @GetMapping("/schedules")
+    public ResponseEntity<List<ReadScheduleResponse>> getAll(
+        @RequestParam(required = false) String name,
+        @RequestParam(required = false) Date date
+    ) {
+        List<ReadScheduleResponse> readScheduleResponses = scheduleService.getAll(name, date);
+
+        return ResponseEntity.ok().body(readScheduleResponses);
+    }
+
+    @GetMapping("/schedules/{id}")
+    public ResponseEntity<ReadScheduleResponse> getById(
+        @PathVariable Long id
+    ) {
+        ReadScheduleResponse readScheduleResponse = scheduleService.getById(id);
+
+        return ResponseEntity.ok().body(readScheduleResponse);
     }
 }

--- a/src/main/java/com/doorcs/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/doorcs/schedule/controller/ScheduleController.java
@@ -1,0 +1,30 @@
+package com.doorcs.schedule.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.doorcs.schedule.service.ScheduleService;
+import com.doorcs.schedule.service.request.CreateScheduleRequest;
+import com.doorcs.schedule.service.response.CreateScheduleResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class ScheduleController {
+
+    private final ScheduleService scheduleService;
+
+    @PostMapping("/schedules")
+    public ResponseEntity<CreateScheduleResponse> create(
+        @RequestBody CreateScheduleRequest createScheduleRequest
+    ) {
+        CreateScheduleResponse createScheduleResponse = scheduleService.create(createScheduleRequest);
+
+        return ResponseEntity.ok().body(createScheduleResponse);
+    }
+}

--- a/src/main/java/com/doorcs/schedule/domain/Schedule.java
+++ b/src/main/java/com/doorcs/schedule/domain/Schedule.java
@@ -1,0 +1,34 @@
+package com.doorcs.schedule.domain;
+
+import java.sql.Date;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class Schedule {
+
+    private Long id;
+    private String content;
+    private String name;
+    private String password;
+    private Date createdAt;
+    private Date modifiedAt;
+
+    public static Schedule of(Long id, String content, String name, String password, Date createdAt, Date modifiedAt) {
+        Schedule schedule = new Schedule();
+        schedule.id = id;
+        schedule.content = content;
+        schedule.name = name;
+        schedule.password = password;
+        schedule.createdAt = createdAt;
+        schedule.modifiedAt = modifiedAt;
+        return schedule;
+    }
+
+    public static Schedule of(String content, String name, String password, Date createdAt) {
+        return of(null, content, name, password, createdAt, createdAt);
+    }
+}

--- a/src/main/java/com/doorcs/schedule/domain/ScheduleRepository.java
+++ b/src/main/java/com/doorcs/schedule/domain/ScheduleRepository.java
@@ -1,5 +1,9 @@
 package com.doorcs.schedule.domain;
 
+import java.sql.Date;
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.sql.DataSource;
 
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -22,6 +26,46 @@ public class ScheduleRepository {
             schedule.getPassword(),
             schedule.getCreatedAt(),
             schedule.getModifiedAt()
+        );
+    }
+
+    public List<Schedule> findAll(String name, Date date) {
+        String sql = "SELECT * FROM schedule WHERE TRUE";
+        List<Object> params = new ArrayList<>();
+
+        if (name != null && !name.isEmpty()) {
+            sql += " AND name = ?";
+            params.add(name);
+        }
+
+        if (date != null) {
+            sql += " AND created_at = ?";
+            params.add(date);
+        }
+
+        sql += " ORDER BY modified_at";
+
+        return jdbcTemplate.query(sql, (rs, rowNum) -> Schedule.of(
+                rs.getLong("id"),
+                rs.getString("content"),
+                rs.getString("name"),
+                rs.getString("password"),
+                rs.getDate("created_at"),
+                rs.getDate("modified_at")
+            ), params.toArray()
+        );
+    }
+
+    public Schedule findById(Long id) {
+        String sql = "SELECT * FROM schedule WHERE id = ?";
+        return jdbcTemplate.queryForObject(sql, (rs, rowNum) -> Schedule.of(
+                rs.getLong("id"),
+                rs.getString("content"),
+                rs.getString("name"),
+                rs.getString("password"),
+                rs.getDate("created_at"),
+                rs.getDate("modified_at")
+            ), id
         );
     }
 }

--- a/src/main/java/com/doorcs/schedule/domain/ScheduleRepository.java
+++ b/src/main/java/com/doorcs/schedule/domain/ScheduleRepository.java
@@ -1,0 +1,27 @@
+package com.doorcs.schedule.domain;
+
+import javax.sql.DataSource;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ScheduleRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public ScheduleRepository(DataSource dataSource) {
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
+    } // 이 생성자는 `@requiredArgsConstructor`로 대체 불가능!!
+
+    public int save(Schedule schedule) {
+        String sql = "INSERT INTO schedule (content, name, password, created_at, modified_at) VALUES (?, ?, ?, ?, ?)";
+        return jdbcTemplate.update(sql,
+            schedule.getContent(),
+            schedule.getName(),
+            schedule.getPassword(),
+            schedule.getCreatedAt(),
+            schedule.getModifiedAt()
+        );
+    }
+}

--- a/src/main/java/com/doorcs/schedule/exception/BadRequestException.java
+++ b/src/main/java/com/doorcs/schedule/exception/BadRequestException.java
@@ -1,0 +1,8 @@
+package com.doorcs.schedule.exception;
+
+public class BadRequestException extends BaseException {
+
+    public BadRequestException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/com/doorcs/schedule/exception/BaseException.java
+++ b/src/main/java/com/doorcs/schedule/exception/BaseException.java
@@ -1,0 +1,8 @@
+package com.doorcs.schedule.exception;
+
+public abstract class BaseException extends RuntimeException {
+
+    public BaseException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/com/doorcs/schedule/exception/NotFoundException.java
+++ b/src/main/java/com/doorcs/schedule/exception/NotFoundException.java
@@ -1,0 +1,8 @@
+package com.doorcs.schedule.exception;
+
+public class NotFoundException extends BaseException {
+
+    public NotFoundException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/com/doorcs/schedule/service/ScheduleService.java
+++ b/src/main/java/com/doorcs/schedule/service/ScheduleService.java
@@ -1,0 +1,41 @@
+package com.doorcs.schedule.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.doorcs.schedule.domain.Schedule;
+import com.doorcs.schedule.domain.ScheduleRepository;
+import com.doorcs.schedule.service.request.CreateScheduleRequest;
+import com.doorcs.schedule.service.response.CreateScheduleResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ScheduleService {
+
+    private final ScheduleRepository scheduleRepository;
+
+    @Transactional
+    public CreateScheduleResponse create(CreateScheduleRequest createScheduleRequest) {
+        int affectedRow = scheduleRepository.save(Schedule.of(
+                // id는 auto increment
+                createScheduleRequest.content(),
+                createScheduleRequest.name(),
+                createScheduleRequest.password(),
+                createScheduleRequest.date()
+                // modified_at 필드는 created_at 필드와 같은 값 사용
+            )
+        );
+
+        if (affectedRow != 1) {
+            throw new RuntimeException("Failed to create schedule");
+        }
+
+        return new CreateScheduleResponse(
+            createScheduleRequest.content(),
+            createScheduleRequest.name(),
+            createScheduleRequest.date()
+        );
+    }
+}

--- a/src/main/java/com/doorcs/schedule/service/ScheduleService.java
+++ b/src/main/java/com/doorcs/schedule/service/ScheduleService.java
@@ -1,5 +1,8 @@
 package com.doorcs.schedule.service;
 
+import java.sql.Date;
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -7,6 +10,7 @@ import com.doorcs.schedule.domain.Schedule;
 import com.doorcs.schedule.domain.ScheduleRepository;
 import com.doorcs.schedule.service.request.CreateScheduleRequest;
 import com.doorcs.schedule.service.response.CreateScheduleResponse;
+import com.doorcs.schedule.service.response.ReadScheduleResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -36,6 +40,27 @@ public class ScheduleService {
             createScheduleRequest.content(),
             createScheduleRequest.name(),
             createScheduleRequest.date()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public List<ReadScheduleResponse> getAll(String name, Date date) {
+        return scheduleRepository.findAll(name, date).stream()
+            .map(schedule -> new ReadScheduleResponse(
+                schedule.getContent(),
+                schedule.getName(),
+                schedule.getModifiedAt()
+            )).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public ReadScheduleResponse getById(Long id) {
+        Schedule schedule = scheduleRepository.findById(id);
+
+        return new ReadScheduleResponse(
+            schedule.getContent(),
+            schedule.getName(),
+            schedule.getModifiedAt()
         );
     }
 }

--- a/src/main/java/com/doorcs/schedule/service/request/CreateScheduleRequest.java
+++ b/src/main/java/com/doorcs/schedule/service/request/CreateScheduleRequest.java
@@ -1,0 +1,6 @@
+package com.doorcs.schedule.service.request;
+
+import java.sql.Date;
+
+public record CreateScheduleRequest(String content, String name, String password, Date date) {
+}

--- a/src/main/java/com/doorcs/schedule/service/response/CreateScheduleResponse.java
+++ b/src/main/java/com/doorcs/schedule/service/response/CreateScheduleResponse.java
@@ -1,0 +1,6 @@
+package com.doorcs.schedule.service.response;
+
+import java.sql.Date;
+
+public record CreateScheduleResponse(String content, String name, Date createdDate) {
+}

--- a/src/main/java/com/doorcs/schedule/service/response/ReadScheduleResponse.java
+++ b/src/main/java/com/doorcs/schedule/service/response/ReadScheduleResponse.java
@@ -1,0 +1,6 @@
+package com.doorcs.schedule.service.response;
+
+import java.sql.Date;
+
+public record ReadScheduleResponse(String content, String name, Date modifiedDate) {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,9 @@
 spring:
   application:
     name: schedule
+
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/schedule
+    username: user
+    password: 1111


### PR DESCRIPTION
## Lv.1 일정 생성 및 조회

- [x] 일정 생성(일정 작성하기)
  - 일정 생성 시, 포함되어야할 데이터
    - 할일, 작성자명, 비밀번호, 작성/수정일을 저장
    - 작성/수정일은 날짜와 시간을 모두 포함한 형태
  - 각 일정의 고유 식별자(ID)를 자동으로 생성하여 관리
  - 최초 입력 시, 수정일은 작성일과 동일
- [x] 전체 일정 조회(등록된 일정 불러오기)
  - 다음 조건을 바탕으로 등록된 일정 목록을 전부 조회
    - 수정일 (형식 : YYYY-MM-DD)
    - 작성자명
  - 조건 중 한 가지만을 충족하거나, 둘 다 충족을 하지 않을 수도, 두 가지를 모두 충족할 수도 있습니다.
  - 수정일 기준 내림차순으로 정렬하여 조회
- [x] 선택 일정 조회(선택한 일정 정보 불러오기)
  - 선택한 일정 단건의 정보를 조회할 수 있습니다.
  - 일정의 고유 식별자(ID)를 사용하여 조회합니다.