### PR TITLE
refactor: 유저 엔티티 분리 및 연관관계 설정

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,18 @@
 | 기능 | 메서드 | URL | 요청 | 응답 | 상태 코드 |
 | --- | --- | --- | --- | --- | --- |
 | 회원가입 | POST | `/api/v2/auth/signup` | RequestBody | ResponseBody | 200, 400 |
-| 로그인 | POST | `/api/v2/auth/signin` | RequestBody | ResponseBody | 200, 400 |
-| 로그아웃 | POST | `/api/v2/auth/signout` | RequestHeader | ResponseBody | 200, 400 | <!-- 로그아웃을 GET으로 구현하면 안된다!!! -->
+| 로그인 | POST | `/api/v2/auth/signin` | RequestBody | Cookie, ResponseBody | 200, 400 |
+| 로그아웃 | POST | `/api/v2/auth/signout` | Cookie | ResponseBody | 200, 400 | <!-- 로그아웃을 GET으로 구현하면 안된다!!! -->
 | - | - | - | - | - | - | <!-- 비밀번호 검증을 위해 RequestBody도 함께 요청 -->
-| 회원정보 수정 | POST | `/api/v2/auth/me` | RequestHeader, RequestBody | ResponseBody | 200, 400 |
-| 회원 탈퇴 | DELETE | `/api/v2/auth/me` | RequestHeader, RequestBody | ResponseBody | 200, 400 |
+| 회원정보 수정 | POST | `/api/v2/auth/me` | Cookie, RequestBody | ResponseBody | 200, 400 |
+| 회원 탈퇴 | DELETE | `/api/v2/auth/me` | Cookie, RequestBody | ResponseBody | 200, 400 |
 | - | - | - | - | - | - |
 | 전체 일정 조회 | GET | `/api/v2/schedules` | (optional) QueryString | ResponseBody | 200 |
 | 선택 일정 조회 | GET | `/api/v2/schedules/{id}` | PathVariable | ResponseBody | 200, 404 |
 | - | - | - | - | - | - | <!-- 일정 생성, 수정, 삭제는 로그인 요구 -->
-| 일정 생성 | POST | `/api/v2/schedules` | RequestHeader, RequestBody | ResponseBody | 200, 400 |
-| 일정 수정 | PUT | `/api/v2/schedules/{id}` | RequestHeader, PathVariable, RequestBody | ResponseBody | 200, 400, 404 |
-| 일정 삭제 | DELETE | `/api/v2/schedules/{id}` | RequestHeader, PathVariable, RequestBody | ResponseBody | 200, 400, 404 |
+| 일정 생성 | POST | `/api/v2/schedules` | Cookie, RequestBody | ResponseBody | 200, 400 |
+| 일정 수정 | PUT | `/api/v2/schedules/{id}` | Cookie, PathVariable, RequestBody | ResponseBody | 200, 400, 404 |
+| 일정 삭제 | DELETE | `/api/v2/schedules/{id}` | Cookie, PathVariable, RequestBody | ResponseBody | 200, 400, 404 |
 
 <details>
 <summary>0-2단계 API 명세 (v1)</summary>

--- a/README.md
+++ b/README.md
@@ -1,32 +1,101 @@
-## API 명세
+## API 명세 (v2)
 
 | 기능 | 메서드 | URL | 요청 | 응답 | 상태 코드 |
 | --- | --- | --- | --- | --- | --- |
-| 일정 생성 | POST | `/api/v1/schedules` | RequestBody | ResponseBody | 201 |
-| 전체 일정 조회 | GET | `/api/v1/schedules` | - | ResponseBody | 200|
-| 선택 일정 조회 | GET | `/api/v1/schedules/{id}` | QueryString | ResponseBody | 200 또는 404 |
-| 일정 수정 | PUT | `/api/v1/schedules/{id}` | QueryString, RequestBody | ResponseBody | 200 또는 404 |
-| 일정 삭제 | DELETE | `/api/v1/schedules/{id}` | QueryString, RequestBody | ResponseBody | 200 또는 404 |
+| 회원가입 | POST | `/api/v2/auth/signup` | RequestBody | ResponseBody | 200, 400 |
+| 로그인 | POST | `/api/v2/auth/signin` | RequestBody | ResponseBody | 200, 400 |
+| 로그아웃 | POST | `/api/v2/auth/signout` | RequestHeader | ResponseBody | 200, 400 | <!-- 로그아웃을 GET으로 구현하면 안된다!!! -->
+| - | - | - | - | - | - | <!-- 비밀번호 검증을 위해 RequestBody도 함께 요청 -->
+| 회원정보 수정 | POST | `/api/v2/auth/me` | RequestHeader, RequestBody | ResponseBody | 200, 400 |
+| 회원 탈퇴 | DELETE | `/api/v2/auth/me` | RequestHeader, RequestBody | ResponseBody | 200, 400 |
+| - | - | - | - | - | - |
+| 전체 일정 조회 | GET | `/api/v2/schedules` | (optional) QueryString | ResponseBody | 200 |
+| 선택 일정 조회 | GET | `/api/v2/schedules/{id}` | PathVariable | ResponseBody | 200, 404 |
+| - | - | - | - | - | - | <!-- 일정 생성, 수정, 삭제는 로그인 요구 -->
+| 일정 생성 | POST | `/api/v2/schedules` | RequestHeader, RequestBody | ResponseBody | 200, 400 |
+| 일정 수정 | PUT | `/api/v2/schedules/{id}` | RequestHeader, PathVariable, RequestBody | ResponseBody | 200, 400, 404 |
+| 일정 삭제 | DELETE | `/api/v2/schedules/{id}` | RequestHeader, PathVariable, RequestBody | ResponseBody | 200, 400, 404 |
 
-## ERD
+<details>
+<summary>0-2단계 API 명세 (v1)</summary>
+
+## API 명세 (v1)
+
+| 기능 | 메서드 | URL | 요청 | 응답 | 상태 코드 |
+| --- | --- | --- | --- | --- | --- |
+| 일정 생성 | POST | `/api/v1/schedules` | RequestBody | ResponseBody | 200, 400 |
+| 전체 일정 조회 | GET | `/api/v1/schedules` | (optional) QueryString | ResponseBody | 200 |
+| 선택 일정 조회 | GET | `/api/v1/schedules/{id}` | PathVariable | ResponseBody | 200, 404 |
+| 일정 수정 | PUT | `/api/v1/schedules/{id}` | PathVariable, RequestBody | ResponseBody | 200, 400, 404 |
+| 일정 삭제 | DELETE | `/api/v1/schedules/{id}` | PathVariable, RequestBody | ResponseBody | 200, 400, 404 |
+</details>
+
+## ERD (v2)
 
 ```mermaid
 erDiagram
-    schedule {
-        Long id
-        TEXT content
+    direction LR
+    user ||--o{ schedule : "1:N"
+
+    user {
+        Long id PK
         VARCHAR name
         VARCHAR password
-        %% 암호를 평문으로 저장하는게 정말 너무 거슬린다....
+    %% 암호를 평문으로 저장하는게 정말 너무 거슬린다....
+        VARCHAR email
         DATE created_at
         DATE modified_at
-        %% 요구사항이 YYYY-MM-DD 형식이므로 DATE 사용
+    %% 요구사항이 YYYY-MM-DD 형식이므로 DATE 사용
     }
+    schedule {
+        Long id PK
+        Long user_id FK
+        TEXT content
+        DATE created_at
+        DATE modified_at
+    %% 요구사항이 YYYY-MM-DD 형식이므로 DATE 사용
+    }
+```
+- SQL
+```sql
+CREATE TABLE user (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    password VARCHAR(255) NOT NULL,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    created_at DATE,
+    modified_at DATE
+);
+
+CREATE TABLE schedule (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    content TEXT NOT NULL,
+    created_at DATE,
+    modified_at DATE,
+    FOREIGN KEY (user_id) REFERENCES user(id)
+);
 ```
 
 <details>
-<summary>테이블 생성 SQL</summary>
+<summary>0-2단계 ERD (v1)</summary>
 
+## ERD (v1)
+```mermaid
+erDiagram
+    schedule {
+        Long id PK
+        TEXT content
+        VARCHAR name
+        VARCHAR password
+    %% 암호를 평문으로 저장하는게 정말 너무 거슬린다....
+        DATE created_at
+        DATE modified_at
+    %% 요구사항이 YYYY-MM-DD 형식이므로 DATE 사용
+    }
+```
+
+- SQL
 ```sql
 CREATE TABLE schedule (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,

--- a/build.gradle
+++ b/build.gradle
@@ -27,8 +27,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'io.jsonwebtoken:jjwt:0.12.6' // JWT
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6' // JWT
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6' // JWT
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/schedule.sql
+++ b/schedule.sql
@@ -1,8 +1,28 @@
-CREATE TABLE schedule (
+CREATE TABLE user (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    content TEXT NOT NULL,
     name VARCHAR(255) NOT NULL,
     password VARCHAR(255) NOT NULL,
+    email VARCHAR(255) NOT NULL UNIQUE,
     created_at DATE,
     modified_at DATE
 );
+
+CREATE TABLE schedule (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    content TEXT NOT NULL,
+    created_at DATE,
+    modified_at DATE,
+    FOREIGN KEY (user_id) REFERENCES user(id)
+);
+
+-- `0 - 2`단계 테이블:
+
+-- CREATE TABLE schedule (
+--     id BIGINT AUTO_INCREMENT PRIMARY KEY,
+--     content TEXT NOT NULL,
+--     name VARCHAR(255) NOT NULL,
+--     password VARCHAR(255) NOT NULL,
+--     created_at DATE,
+--     modified_at DATE
+-- );

--- a/src/main/java/com/doorcs/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/doorcs/schedule/controller/ScheduleController.java
@@ -62,16 +62,17 @@ public class ScheduleController {
         return ResponseEntity.ok().body(readScheduleResponse);
     }
 
-    // @PutMapping("/schedules/{id}")
-    // public ResponseEntity<UpdateScheduleResponse> update(
-    //     @PathVariable Long id,
-    //     @RequestBody UpdateScheduleRequest updateScheduleRequest
-    // ) {
-    //     UpdateScheduleResponse updateScheduleResponse = scheduleService.update(id, updateScheduleRequest);
-    //
-    //     return ResponseEntity.ok().body(updateScheduleResponse);
-    // }
-    //
+    @PutMapping("/schedules/{id}")
+    public ResponseEntity<UpdateScheduleResponse> update(
+        @CookieValue String jwt,
+        @PathVariable Long id,
+        @RequestBody UpdateScheduleRequest updateScheduleRequest
+    ) {
+        UpdateScheduleResponse updateScheduleResponse = scheduleService.update(jwt, id, updateScheduleRequest);
+
+        return ResponseEntity.ok().body(updateScheduleResponse);
+    }
+
     // @DeleteMapping("/schedules/{id}")
     // public ResponseEntity<DeleteScheduleResponse> delete(
     //     @PathVariable Long id,

--- a/src/main/java/com/doorcs/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/doorcs/schedule/controller/ScheduleController.java
@@ -26,57 +26,57 @@ import com.doorcs.schedule.service.response.UpdateScheduleResponse;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v2")
 @RequiredArgsConstructor
 public class ScheduleController {
 
     private final ScheduleService scheduleService;
 
-    @PostMapping("/schedules")
-    public ResponseEntity<CreateScheduleResponse> create(
-        @RequestBody CreateScheduleRequest createScheduleRequest
-    ) {
-        CreateScheduleResponse createScheduleResponse = scheduleService.create(createScheduleRequest);
-
-        return ResponseEntity.ok().body(createScheduleResponse);
-    }
+    // @PostMapping("/schedules")
+    // public ResponseEntity<CreateScheduleResponse> create(
+    //     @RequestBody CreateScheduleRequest createScheduleRequest
+    // ) {
+    //     CreateScheduleResponse createScheduleResponse = scheduleService.create(createScheduleRequest);
+    //
+    //     return ResponseEntity.ok().body(createScheduleResponse);
+    // }
 
     @GetMapping("/schedules")
     public ResponseEntity<List<ReadScheduleResponse>> getAll(
-        @RequestParam(required = false) String name,
-        @RequestParam(required = false) Date date
+        @RequestParam(required = false) Long userId,
+        @RequestParam(required = false) Date modifiedDate
     ) {
-        List<ReadScheduleResponse> readScheduleResponses = scheduleService.getAll(name, date);
+        List<ReadScheduleResponse> readScheduleResponses = scheduleService.getAll(userId, modifiedDate);
 
         return ResponseEntity.ok().body(readScheduleResponses);
     }
 
     @GetMapping("/schedules/{id}")
     public ResponseEntity<ReadScheduleResponse> getById(
-        @PathVariable Long id
+        @PathVariable Long id // Schedule의 ID!
     ) {
         ReadScheduleResponse readScheduleResponse = scheduleService.getById(id);
 
         return ResponseEntity.ok().body(readScheduleResponse);
     }
 
-    @PutMapping("/schedules/{id}")
-    public ResponseEntity<UpdateScheduleResponse> update(
-        @PathVariable Long id,
-        @RequestBody UpdateScheduleRequest updateScheduleRequest
-    ) {
-        UpdateScheduleResponse updateScheduleResponse = scheduleService.update(id, updateScheduleRequest);
-
-        return ResponseEntity.ok().body(updateScheduleResponse);
-    }
-
-    @DeleteMapping("/schedules/{id}")
-    public ResponseEntity<DeleteScheduleResponse> delete(
-        @PathVariable Long id,
-        @RequestBody DeleteScheduleRequest password
-    ) {
-        DeleteScheduleResponse deleted = scheduleService.delete(id, password.password());
-
-        return ResponseEntity.ok().body(deleted);
-    }
+    // @PutMapping("/schedules/{id}")
+    // public ResponseEntity<UpdateScheduleResponse> update(
+    //     @PathVariable Long id,
+    //     @RequestBody UpdateScheduleRequest updateScheduleRequest
+    // ) {
+    //     UpdateScheduleResponse updateScheduleResponse = scheduleService.update(id, updateScheduleRequest);
+    //
+    //     return ResponseEntity.ok().body(updateScheduleResponse);
+    // }
+    //
+    // @DeleteMapping("/schedules/{id}")
+    // public ResponseEntity<DeleteScheduleResponse> delete(
+    //     @PathVariable Long id,
+    //     @RequestBody DeleteScheduleRequest password
+    // ) {
+    //     DeleteScheduleResponse deleted = scheduleService.delete(id, password.password());
+    //
+    //     return ResponseEntity.ok().body(deleted);
+    // }
 }

--- a/src/main/java/com/doorcs/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/doorcs/schedule/controller/ScheduleController.java
@@ -17,7 +17,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.doorcs.schedule.service.ScheduleService;
 import com.doorcs.schedule.service.request.CreateScheduleRequest;
-import com.doorcs.schedule.service.request.DeleteScheduleRequest;
 import com.doorcs.schedule.service.request.UpdateScheduleRequest;
 import com.doorcs.schedule.service.response.CreateScheduleResponse;
 import com.doorcs.schedule.service.response.DeleteScheduleResponse;
@@ -73,13 +72,13 @@ public class ScheduleController {
         return ResponseEntity.ok().body(updateScheduleResponse);
     }
 
-    // @DeleteMapping("/schedules/{id}")
-    // public ResponseEntity<DeleteScheduleResponse> delete(
-    //     @PathVariable Long id,
-    //     @RequestBody DeleteScheduleRequest password
-    // ) {
-    //     DeleteScheduleResponse deleted = scheduleService.delete(id, password.password());
-    //
-    //     return ResponseEntity.ok().body(deleted);
-    // }
+    @DeleteMapping("/schedules/{id}")
+    public ResponseEntity<DeleteScheduleResponse> delete(
+        @CookieValue String jwt,
+        @PathVariable Long id
+    ) {
+        DeleteScheduleResponse deleted = scheduleService.delete(jwt, id);
+
+        return ResponseEntity.ok().body(deleted);
+    }
 }

--- a/src/main/java/com/doorcs/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/doorcs/schedule/controller/ScheduleController.java
@@ -4,6 +4,7 @@ import java.sql.Date;
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -32,14 +33,15 @@ public class ScheduleController {
 
     private final ScheduleService scheduleService;
 
-    // @PostMapping("/schedules")
-    // public ResponseEntity<CreateScheduleResponse> create(
-    //     @RequestBody CreateScheduleRequest createScheduleRequest
-    // ) {
-    //     CreateScheduleResponse createScheduleResponse = scheduleService.create(createScheduleRequest);
-    //
-    //     return ResponseEntity.ok().body(createScheduleResponse);
-    // }
+    @PostMapping("/schedules")
+    public ResponseEntity<CreateScheduleResponse> create(
+        @CookieValue String jwt,
+        @RequestBody CreateScheduleRequest createScheduleRequest
+    ) {
+        CreateScheduleResponse createScheduleResponse = scheduleService.create(jwt, createScheduleRequest);
+
+        return ResponseEntity.ok().body(createScheduleResponse);
+    }
 
     @GetMapping("/schedules")
     public ResponseEntity<List<ReadScheduleResponse>> getAll(

--- a/src/main/java/com/doorcs/schedule/controller/UserController.java
+++ b/src/main/java/com/doorcs/schedule/controller/UserController.java
@@ -1,5 +1,7 @@
 package com.doorcs.schedule.controller;
 
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -8,7 +10,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.doorcs.schedule.service.UserService;
 import com.doorcs.schedule.service.request.CreateUserRequest;
+import com.doorcs.schedule.service.request.SigninRequest;
 import com.doorcs.schedule.service.response.CreateUserResponse;
+import com.doorcs.schedule.service.response.SigninResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -26,5 +30,20 @@ public class UserController {
         CreateUserResponse createUserResponse = userService.create(createUserRequest);
 
         return ResponseEntity.ok().body(createUserResponse);
+    }
+
+    @PostMapping("/auth/signin")
+    public ResponseEntity<SigninResponse> signinUser(
+        @RequestBody SigninRequest signinRequest
+    ) {
+        SigninResponse signinResponse = userService.signin(signinRequest);
+        ResponseCookie responseCookie = ResponseCookie.from("jwt", signinResponse.jwt())
+            .httpOnly(true)
+            .path("/")
+            .build(); // 세션 쿠키
+
+        return ResponseEntity.ok()
+            .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
+            .body(signinResponse);
     }
 }

--- a/src/main/java/com/doorcs/schedule/controller/UserController.java
+++ b/src/main/java/com/doorcs/schedule/controller/UserController.java
@@ -1,0 +1,30 @@
+package com.doorcs.schedule.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.doorcs.schedule.service.UserService;
+import com.doorcs.schedule.service.request.CreateUserRequest;
+import com.doorcs.schedule.service.response.CreateUserResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v2")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/auth/signup")
+    public ResponseEntity<CreateUserResponse> createUser(
+        @RequestBody CreateUserRequest createUserRequest
+    ) {
+        CreateUserResponse createUserResponse = userService.create(createUserRequest);
+
+        return ResponseEntity.ok().body(createUserResponse);
+    }
+}

--- a/src/main/java/com/doorcs/schedule/controller/UserController.java
+++ b/src/main/java/com/doorcs/schedule/controller/UserController.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,9 +12,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.doorcs.schedule.service.UserService;
 import com.doorcs.schedule.service.request.CreateUserRequest;
+import com.doorcs.schedule.service.request.DeleteUserRequest;
 import com.doorcs.schedule.service.request.SigninRequest;
 import com.doorcs.schedule.service.request.UpdateUserRequest;
 import com.doorcs.schedule.service.response.CreateUserResponse;
+import com.doorcs.schedule.service.response.DeleteUserResponse;
 import com.doorcs.schedule.service.response.SigninResponse;
 import com.doorcs.schedule.service.response.SignoutResponse;
 import com.doorcs.schedule.service.response.UpdateUserResponse;
@@ -72,5 +75,16 @@ public class UserController {
         UpdateUserResponse updateUserResponse = userService.update(jwt, updateUserRequest);
 
         return ResponseEntity.ok().body(updateUserResponse);
+    }
+
+    @DeleteMapping("/auth/me")
+    public ResponseEntity<DeleteUserResponse> deleteUser(
+        @CookieValue String jwt,
+        @RequestBody DeleteUserRequest password
+    ) {
+        DeleteUserResponse deleteUserResponse = userService.delete(jwt, password.password());
+
+        signoutUser(); // 로그아웃 처리!
+        return ResponseEntity.ok().body(deleteUserResponse);
     }
 }

--- a/src/main/java/com/doorcs/schedule/controller/UserController.java
+++ b/src/main/java/com/doorcs/schedule/controller/UserController.java
@@ -13,6 +13,7 @@ import com.doorcs.schedule.service.request.CreateUserRequest;
 import com.doorcs.schedule.service.request.SigninRequest;
 import com.doorcs.schedule.service.response.CreateUserResponse;
 import com.doorcs.schedule.service.response.SigninResponse;
+import com.doorcs.schedule.service.response.SignoutResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -45,5 +46,18 @@ public class UserController {
         return ResponseEntity.ok()
             .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
             .body(signinResponse);
+    }
+
+    @PostMapping("/auth/signout")
+    public ResponseEntity<SignoutResponse> signoutUser() {
+        ResponseCookie responseCookie = ResponseCookie.from("jwt", "")
+            .httpOnly(true)
+            .path("/")
+            .maxAge(0) // 쿠키를 즉시 만료시킴
+            .build();
+
+        return ResponseEntity.ok()
+            .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
+            .body(new SignoutResponse("로그아웃 성공"));
     }
 }

--- a/src/main/java/com/doorcs/schedule/controller/UserController.java
+++ b/src/main/java/com/doorcs/schedule/controller/UserController.java
@@ -3,6 +3,7 @@ package com.doorcs.schedule.controller;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,9 +12,11 @@ import org.springframework.web.bind.annotation.RestController;
 import com.doorcs.schedule.service.UserService;
 import com.doorcs.schedule.service.request.CreateUserRequest;
 import com.doorcs.schedule.service.request.SigninRequest;
+import com.doorcs.schedule.service.request.UpdateUserRequest;
 import com.doorcs.schedule.service.response.CreateUserResponse;
 import com.doorcs.schedule.service.response.SigninResponse;
 import com.doorcs.schedule.service.response.SignoutResponse;
+import com.doorcs.schedule.service.response.UpdateUserResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -59,5 +62,15 @@ public class UserController {
         return ResponseEntity.ok()
             .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
             .body(new SignoutResponse("로그아웃 성공"));
+    }
+
+    @PostMapping("/auth/me")
+    public ResponseEntity<UpdateUserResponse> updateUser(
+        @CookieValue String jwt,
+        @RequestBody UpdateUserRequest updateUserRequest
+    ) {
+        UpdateUserResponse updateUserResponse = userService.update(jwt, updateUserRequest);
+
+        return ResponseEntity.ok().body(updateUserResponse);
     }
 }

--- a/src/main/java/com/doorcs/schedule/domain/Schedule.java
+++ b/src/main/java/com/doorcs/schedule/domain/Schedule.java
@@ -11,30 +11,27 @@ import lombok.NoArgsConstructor;
 public class Schedule {
 
     private Long id;
+    private Long userId; // FK
     private String content;
-    private String name;
-    private String password;
     private Date createdAt;
     private Date modifiedAt;
 
-    public static Schedule of(Long id, String content, String name, String password, Date createdAt, Date modifiedAt) {
+    public static Schedule of(Long id, Long userId, String content, Date createdAt, Date modifiedAt) {
         Schedule schedule = new Schedule();
         schedule.id = id;
+        schedule.userId = userId;
         schedule.content = content;
-        schedule.name = name;
-        schedule.password = password;
         schedule.createdAt = createdAt;
         schedule.modifiedAt = modifiedAt;
         return schedule;
     }
 
-    public static Schedule of(String content, String name, String password, Date createdAt) {
-        return of(null, content, name, password, createdAt, createdAt);
+    public static Schedule of(Long userId, String content, Date createdAt) {
+        return of(null, userId, content, createdAt, createdAt);
     }
 
-    public void update(String content, String name) {
+    public void update(String content) {
         this.content = content;
-        this.name = name;
         this.modifiedAt = new Date(System.currentTimeMillis());
     }
 }

--- a/src/main/java/com/doorcs/schedule/domain/ScheduleRepository.java
+++ b/src/main/java/com/doorcs/schedule/domain/ScheduleRepository.java
@@ -75,8 +75,8 @@ public class ScheduleRepository {
         );
     }
 
-    // public int delete(Long id) {
-    //     String sql = "DELETE FROM schedule WHERE id = ?";
-    //     return jdbcTemplate.update(sql, id);
-    // }
+    public int delete(Long id) {
+        String sql = "DELETE FROM schedule WHERE id = ?";
+        return jdbcTemplate.update(sql, id);
+    }
 }

--- a/src/main/java/com/doorcs/schedule/domain/ScheduleRepository.java
+++ b/src/main/java/com/doorcs/schedule/domain/ScheduleRepository.java
@@ -19,27 +19,26 @@ public class ScheduleRepository {
     } // 이 생성자는 `@requiredArgsConstructor`로 대체 불가능!!
 
     public int save(Schedule schedule) {
-        String sql = "INSERT INTO schedule (content, name, password, created_at, modified_at) VALUES (?, ?, ?, ?, ?)";
+        String sql = "INSERT INTO schedule (content, user_id, created_at, modified_at) VALUES (?, ?, ?, ?)";
         return jdbcTemplate.update(sql,
             schedule.getContent(),
-            schedule.getName(),
-            schedule.getPassword(),
+            schedule.getUserId(),
             schedule.getCreatedAt(),
             schedule.getModifiedAt()
         );
     }
 
-    public List<Schedule> findAll(String name, Date date) {
+    public List<Schedule> findAll(Long userId, Date date) {
         String sql = "SELECT * FROM schedule WHERE TRUE";
         List<Object> params = new ArrayList<>();
 
-        if (name != null && !name.isEmpty()) {
-            sql += " AND name = ?";
-            params.add(name);
+        if (userId != null) {
+            sql += " AND user_id = ?";
+            params.add(userId);
         }
 
         if (date != null) {
-            sql += " AND created_at = ?";
+            sql += " AND modified_at = ?";
             params.add(date);
         }
 
@@ -47,9 +46,8 @@ public class ScheduleRepository {
 
         return jdbcTemplate.query(sql, (rs, rowNum) -> Schedule.of(
                 rs.getLong("id"),
+                rs.getLong("user_id"),
                 rs.getString("content"),
-                rs.getString("name"),
-                rs.getString("password"),
                 rs.getDate("created_at"),
                 rs.getDate("modified_at")
             ), params.toArray()
@@ -60,27 +58,26 @@ public class ScheduleRepository {
         String sql = "SELECT * FROM schedule WHERE id = ?";
         return jdbcTemplate.queryForObject(sql, (rs, rowNum) -> Schedule.of(
                 rs.getLong("id"),
+                rs.getLong("user_id"),
                 rs.getString("content"),
-                rs.getString("name"),
-                rs.getString("password"),
                 rs.getDate("created_at"),
                 rs.getDate("modified_at")
             ), id
         );
     }
 
-    public int update(Schedule schedule) {
-        String sql = "UPDATE schedule SET content = ?, name = ?, modified_at = ? WHERE id = ?";
-        return jdbcTemplate.update(sql,
-            schedule.getContent(),
-            schedule.getName(),
-            schedule.getModifiedAt(),
-            schedule.getId()
-        );
-    }
-
-    public int delete(Long id) {
-        String sql = "DELETE FROM schedule WHERE id = ?";
-        return jdbcTemplate.update(sql, id);
-    }
+    // public int update(Schedule schedule) {
+    //     String sql = "UPDATE schedule SET content = ?, name = ?, modified_at = ? WHERE id = ?";
+    //     return jdbcTemplate.update(sql,
+    //         schedule.getContent(),
+    //         schedule.getName(),
+    //         schedule.getModifiedAt(),
+    //         schedule.getId()
+    //     );
+    // }
+    //
+    // public int delete(Long id) {
+    //     String sql = "DELETE FROM schedule WHERE id = ?";
+    //     return jdbcTemplate.update(sql, id);
+    // }
 }

--- a/src/main/java/com/doorcs/schedule/domain/ScheduleRepository.java
+++ b/src/main/java/com/doorcs/schedule/domain/ScheduleRepository.java
@@ -66,16 +66,15 @@ public class ScheduleRepository {
         );
     }
 
-    // public int update(Schedule schedule) {
-    //     String sql = "UPDATE schedule SET content = ?, name = ?, modified_at = ? WHERE id = ?";
-    //     return jdbcTemplate.update(sql,
-    //         schedule.getContent(),
-    //         schedule.getName(),
-    //         schedule.getModifiedAt(),
-    //         schedule.getId()
-    //     );
-    // }
-    //
+    public int update(Schedule schedule) {
+        String sql = "UPDATE schedule SET content = ?, modified_at = ? WHERE id = ?";
+        return jdbcTemplate.update(sql,
+            schedule.getContent(),
+            schedule.getModifiedAt(),
+            schedule.getId()
+        );
+    }
+
     // public int delete(Long id) {
     //     String sql = "DELETE FROM schedule WHERE id = ?";
     //     return jdbcTemplate.update(sql, id);

--- a/src/main/java/com/doorcs/schedule/domain/User.java
+++ b/src/main/java/com/doorcs/schedule/domain/User.java
@@ -1,0 +1,41 @@
+package com.doorcs.schedule.domain;
+
+import java.sql.Date;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class User {
+
+    private Long id;
+    private String name;
+    private String password;
+    private String email;
+    private Date createdAt;
+    private Date modifiedAt;
+
+    public static User of(Long id, String name, String password, String email, Date createdAt, Date modifiedAt) {
+        User user = new User();
+        user.id = id;
+        user.name = name;
+        user.password = password;
+        user.email = email;
+        user.createdAt = createdAt;
+        user.modifiedAt = modifiedAt;
+        return user;
+    }
+
+    public static User of(String name, String password, String email, Date createdAt) {
+        return of(null, name, password, email, createdAt, createdAt);
+    }
+
+    public void update(String name, String password, String email) {
+        this.name = name;
+        this.password = password;
+        this.email = email;
+        this.modifiedAt = new Date(System.currentTimeMillis());
+    }
+}

--- a/src/main/java/com/doorcs/schedule/domain/UserRepository.java
+++ b/src/main/java/com/doorcs/schedule/domain/UserRepository.java
@@ -1,0 +1,27 @@
+package com.doorcs.schedule.domain;
+
+import javax.sql.DataSource;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class UserRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public UserRepository(DataSource dataSource) {
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
+    }
+
+    public int save(User user) {
+        String sql = "INSERT INTO user (name, password, email, created_at, modified_at) VALUES (?, ?, ?, ?, ?)";
+        return jdbcTemplate.update(sql,
+            user.getName(),
+            user.getPassword(),
+            user.getEmail(),
+            user.getCreatedAt(),
+            user.getModifiedAt()
+        );
+    }
+}

--- a/src/main/java/com/doorcs/schedule/domain/UserRepository.java
+++ b/src/main/java/com/doorcs/schedule/domain/UserRepository.java
@@ -37,4 +37,28 @@ public class UserRepository {
             ), email
         );
     }
+
+    public User findById(Long userId) {
+        String sql = "SELECT * FROM user WHERE id = ?";
+        return jdbcTemplate.queryForObject(sql, (rs, rowNum) -> User.of(
+                rs.getLong("id"),
+                rs.getString("name"),
+                rs.getString("password"),
+                rs.getString("email"),
+                rs.getDate("created_at"),
+                rs.getDate("modified_at")
+            ), userId
+        );
+    }
+
+    public int update(User user) {
+        String sql = "UPDATE user SET name = ?, password = ?, email = ?, modified_at = ? WHERE id = ?";
+        return jdbcTemplate.update(sql,
+            user.getName(),
+            user.getPassword(),
+            user.getEmail(),
+            user.getModifiedAt(),
+            user.getId()
+        );
+    }
 }

--- a/src/main/java/com/doorcs/schedule/domain/UserRepository.java
+++ b/src/main/java/com/doorcs/schedule/domain/UserRepository.java
@@ -61,4 +61,9 @@ public class UserRepository {
             user.getId()
         );
     }
+
+    public int delete(Long userId) {
+        String sql = "DELETE FROM user WHERE id = ?";
+        return jdbcTemplate.update(sql, userId);
+    }
 }

--- a/src/main/java/com/doorcs/schedule/domain/UserRepository.java
+++ b/src/main/java/com/doorcs/schedule/domain/UserRepository.java
@@ -24,4 +24,17 @@ public class UserRepository {
             user.getModifiedAt()
         );
     }
+
+    public User findByEmail(String email) {
+        String sql = "SELECT * FROM user WHERE email = ?";
+        return jdbcTemplate.queryForObject(sql, (rs, rowNum) -> User.of(
+                rs.getLong("id"),
+                rs.getString("name"),
+                rs.getString("password"),
+                rs.getString("email"),
+                rs.getDate("created_at"),
+                rs.getDate("modified_at")
+            ), email
+        );
+    }
 }

--- a/src/main/java/com/doorcs/schedule/jwt/JwtUtil.java
+++ b/src/main/java/com/doorcs/schedule/jwt/JwtUtil.java
@@ -1,0 +1,34 @@
+package com.doorcs.schedule.jwt;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.NoArgsConstructor;
+
+@Component
+@NoArgsConstructor
+public class JwtUtil {
+
+    private final SecretKey key = Keys.hmacShaKeyFor(
+        "61da679034fee316bff8aa5f5fdcee0e2df1787af393b904bc43242f9993ef8b".getBytes()
+    ); // 간단한 구현을 위해 환경변수 분리 없이 키 값을 하드코딩
+
+    public String createJwt(Long userId) {
+        return Jwts.builder()
+            .claim("userId", userId.toString())
+            .signWith(key)
+            .compact();
+    }
+
+    public Long getUserId(String token) {
+        return Jwts.parser()
+            .verifyWith(key) // 검증
+            .build()
+            .parseSignedClaims(token)
+            .getPayload()
+            .get("userId", Long.class); // 페이로드에서 사용자 ID만 추출
+    }
+}

--- a/src/main/java/com/doorcs/schedule/jwt/JwtUtil.java
+++ b/src/main/java/com/doorcs/schedule/jwt/JwtUtil.java
@@ -24,11 +24,14 @@ public class JwtUtil {
     }
 
     public Long getUserId(String token) {
-        return Jwts.parser()
-            .verifyWith(key) // 검증
-            .build()
-            .parseSignedClaims(token)
-            .getPayload()
-            .get("userId", Long.class); // 페이로드에서 사용자 ID만 추출
+        return Long.parseLong( // Long 타입으로 캐스팅
+            Jwts.parser()
+                .verifyWith(key) // 검증
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                // .get("userId", Long.class)
+                .get("userId", String.class) // 페이로드에서 사용자 ID만 추출
+        );
     }
 }

--- a/src/main/java/com/doorcs/schedule/service/ScheduleService.java
+++ b/src/main/java/com/doorcs/schedule/service/ScheduleService.java
@@ -79,42 +79,43 @@ public class ScheduleService {
         );
     }
 
-    // @Transactional
-    // public UpdateScheduleResponse update(
-    //     Long id,
-    //     UpdateScheduleRequest updateScheduleRequest
-    // ) {
-    //     Schedule schedule = scheduleRepository.findById(id);
-    //
-    //     if (updateScheduleRequest.password() == null ||
-    //         updateScheduleRequest.password().isEmpty() ||
-    //         !schedule.getPassword().equals(updateScheduleRequest.password())
-    //     ) {
-    //         throw new BadRequestException("비밀번호가 틀립니다.");
-    //     }
-    //
-    //     if (updateScheduleRequest.content() == null && updateScheduleRequest.name() == null) {
-    //         throw new BadRequestException("수정할 내용이 없습니다.");
-    //     }
-    //
-    //     schedule.update(
-    //         updateScheduleRequest.content() != null ? updateScheduleRequest.content() : schedule.getContent(),
-    //         updateScheduleRequest.name() != null ? updateScheduleRequest.name() : schedule.getName()
-    //     );
-    //
-    //     int affectedRow = scheduleRepository.update(schedule);
-    //
-    //     if (affectedRow != 1) {
-    //         throw new BadRequestException("일정 수정을 실패했습니다.");
-    //     }
-    //
-    //     return new UpdateScheduleResponse(
-    //         schedule.getContent(),
-    //         schedule.getName(),
-    //         schedule.getModifiedAt()
-    //     );
-    // }
-//
+    @Transactional
+    public UpdateScheduleResponse update(
+        String jwt,
+        Long id,
+        UpdateScheduleRequest updateScheduleRequest
+    ) {
+        Long userId = jwtUtil.getUserId(jwt);
+        Schedule schedule = scheduleRepository.findById(id);
+
+        if (schedule == null) {
+            throw new BadRequestException("존재하지 않는 일정입니다.");
+        }
+
+        if (!schedule.getUserId().equals(userId)) {
+            throw new BadRequestException("로그인이 필요합니다.");
+        }
+
+        if (updateScheduleRequest.content() == null) {
+            throw new BadRequestException("수정할 내용이 없습니다.");
+        }
+
+        schedule.update(
+            updateScheduleRequest.content()
+        );
+
+        int affectedRow = scheduleRepository.update(schedule);
+
+        if (affectedRow != 1) {
+            throw new BadRequestException("일정 수정을 실패했습니다.");
+        }
+
+        return new UpdateScheduleResponse(
+            schedule.getContent(),
+            schedule.getModifiedAt()
+        );
+    }
+
 //     @Transactional
 //     public DeleteScheduleResponse delete(Long id, String password) {
 //         Schedule schedule = scheduleRepository.findById(id);

--- a/src/main/java/com/doorcs/schedule/service/ScheduleService.java
+++ b/src/main/java/com/doorcs/schedule/service/ScheduleService.java
@@ -15,6 +15,7 @@ import com.doorcs.schedule.jwt.JwtUtil;
 import com.doorcs.schedule.service.request.CreateScheduleRequest;
 import com.doorcs.schedule.service.request.UpdateScheduleRequest;
 import com.doorcs.schedule.service.response.CreateScheduleResponse;
+import com.doorcs.schedule.service.response.DeleteScheduleResponse;
 import com.doorcs.schedule.service.response.ReadScheduleResponse;
 import com.doorcs.schedule.service.response.UpdateScheduleResponse;
 
@@ -116,20 +117,25 @@ public class ScheduleService {
         );
     }
 
-//     @Transactional
-//     public DeleteScheduleResponse delete(Long id, String password) {
-//         Schedule schedule = scheduleRepository.findById(id);
-//
-//         if (password == null || password.isEmpty() || !schedule.getPassword().equals(password)) {
-//             throw new BadRequestException("비밀번호가 틀립니다.");
-//         }
-//
-//         int affectedRow = scheduleRepository.delete(id);
-//
-//         if (affectedRow != 1) {
-//             throw new BadRequestException("일정 삭제를 실패했습니다.");
-//         }
-//
-//         return new DeleteScheduleResponse(id);
-//     }
+    @Transactional
+    public DeleteScheduleResponse delete(String jwt, Long id) {
+        Long userId = jwtUtil.getUserId(jwt);
+        Schedule schedule = scheduleRepository.findById(id);
+
+        if (schedule == null) {
+            throw new BadRequestException("존재하지 않는 일정입니다.");
+        }
+
+        if (!schedule.getUserId().equals(userId)) {
+            throw new BadRequestException("로그인이 필요합니다.");
+        }
+
+        int affectedRow = scheduleRepository.delete(id);
+
+        if (affectedRow != 1) {
+            throw new BadRequestException("일정 삭제를 실패했습니다.");
+        }
+
+        return new DeleteScheduleResponse(id, schedule.getContent());
+    }
 }

--- a/src/main/java/com/doorcs/schedule/service/ScheduleService.java
+++ b/src/main/java/com/doorcs/schedule/service/ScheduleService.java
@@ -8,11 +8,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.doorcs.schedule.domain.Schedule;
 import com.doorcs.schedule.domain.ScheduleRepository;
+import com.doorcs.schedule.domain.User;
+import com.doorcs.schedule.domain.UserRepository;
 import com.doorcs.schedule.exception.BadRequestException;
 import com.doorcs.schedule.service.request.CreateScheduleRequest;
 import com.doorcs.schedule.service.request.UpdateScheduleRequest;
 import com.doorcs.schedule.service.response.CreateScheduleResponse;
-import com.doorcs.schedule.service.response.DeleteScheduleResponse;
 import com.doorcs.schedule.service.response.ReadScheduleResponse;
 import com.doorcs.schedule.service.response.UpdateScheduleResponse;
 
@@ -23,101 +24,106 @@ import lombok.RequiredArgsConstructor;
 public class ScheduleService {
 
     private final ScheduleRepository scheduleRepository;
+    private final UserRepository userRepository;
 
-    @Transactional
-    public CreateScheduleResponse create(CreateScheduleRequest createScheduleRequest) {
-        int affectedRow = scheduleRepository.save(Schedule.of(
-                // id는 auto increment
-                createScheduleRequest.content(),
-                createScheduleRequest.name(),
-                createScheduleRequest.password(),
-                createScheduleRequest.date()
-                // modified_at 필드는 created_at 필드와 같은 값 사용
-            )
-        );
-
-        if (affectedRow != 1) {
-            throw new BadRequestException("일정 생성을 실패했습니다.");
-        }
-
-        return new CreateScheduleResponse(
-            createScheduleRequest.content(),
-            createScheduleRequest.name(),
-            createScheduleRequest.date()
-        );
-    }
+    // @Transactional
+    // public CreateScheduleResponse create(CreateScheduleRequest createScheduleRequest) {
+    //     int affectedRow = scheduleRepository.save(Schedule.of(
+    //             // id는 auto increment
+    //             createScheduleRequest.content(),
+    //             createScheduleRequest.userId(),
+    //             createScheduleRequest.date()
+    //             // modified_at 필드는 created_at 필드와 같은 값 사용
+    //         )
+    //     );
+    //
+    //     if (affectedRow != 1) {
+    //         throw new BadRequestException("일정 생성을 실패했습니다.");
+    //     }
+    //
+    //     return new CreateScheduleResponse(
+    //         createScheduleRequest.content(),
+    //         createScheduleRequest.name(),
+    //         createScheduleRequest.date()
+    //     );
+    // }
 
     @Transactional(readOnly = true)
-    public List<ReadScheduleResponse> getAll(String name, Date date) {
-        return scheduleRepository.findAll(name, date).stream()
-            .map(schedule -> new ReadScheduleResponse(
-                schedule.getContent(),
-                schedule.getName(),
-                schedule.getModifiedAt()
-            )).toList();
+    public List<ReadScheduleResponse> getAll(Long userId, Date date) {
+        return scheduleRepository.findAll(userId, date).stream()
+            .map(schedule -> {
+                User user = userRepository.findById(schedule.getUserId());
+                String userName = user != null ? user.getName() : "탈퇴한 사용자";
+                return new ReadScheduleResponse(
+                    schedule.getContent(),
+                    userName,
+                    schedule.getModifiedAt()
+                );
+            }).toList();
     }
 
     @Transactional(readOnly = true)
     public ReadScheduleResponse getById(Long id) {
         Schedule schedule = scheduleRepository.findById(id);
-
+        User user = userRepository.findById(schedule.getUserId());
+        String userName = user != null ? user.getName() : "탈퇴한 사용자";
         return new ReadScheduleResponse(
             schedule.getContent(),
-            schedule.getName(),
+            userName,
             schedule.getModifiedAt()
         );
     }
 
-    @Transactional
-    public UpdateScheduleResponse update(
-        Long id,
-        UpdateScheduleRequest updateScheduleRequest
-    ) {
-        Schedule schedule = scheduleRepository.findById(id);
-
-        if (updateScheduleRequest.password() == null ||
-            updateScheduleRequest.password().isEmpty() ||
-            !schedule.getPassword().equals(updateScheduleRequest.password())
-        ) {
-            throw new BadRequestException("비밀번호가 틀립니다.");
-        }
-
-        if (updateScheduleRequest.content() == null && updateScheduleRequest.name() == null) {
-            throw new BadRequestException("수정할 내용이 없습니다.");
-        }
-
-        schedule.update(
-            updateScheduleRequest.content() != null ? updateScheduleRequest.content() : schedule.getContent(),
-            updateScheduleRequest.name() != null ? updateScheduleRequest.name() : schedule.getName()
-        );
-
-        int affectedRow = scheduleRepository.update(schedule);
-
-        if (affectedRow != 1) {
-            throw new BadRequestException("일정 수정을 실패했습니다.");
-        }
-
-        return new UpdateScheduleResponse(
-            schedule.getContent(),
-            schedule.getName(),
-            schedule.getModifiedAt()
-        );
-    }
-
-    @Transactional
-    public DeleteScheduleResponse delete(Long id, String password) {
-        Schedule schedule = scheduleRepository.findById(id);
-
-        if (password == null || password.isEmpty() || !schedule.getPassword().equals(password)) {
-            throw new BadRequestException("비밀번호가 틀립니다.");
-        }
-
-        int affectedRow = scheduleRepository.delete(id);
-
-        if (affectedRow != 1) {
-            throw new BadRequestException("일정 삭제를 실패했습니다.");
-        }
-
-        return new DeleteScheduleResponse(id);
-    }
+    // @Transactional
+    // public UpdateScheduleResponse update(
+    //     Long id,
+    //     UpdateScheduleRequest updateScheduleRequest
+    // ) {
+    //     Schedule schedule = scheduleRepository.findById(id);
+    //
+    //     if (updateScheduleRequest.password() == null ||
+    //         updateScheduleRequest.password().isEmpty() ||
+    //         !schedule.getPassword().equals(updateScheduleRequest.password())
+    //     ) {
+    //         throw new BadRequestException("비밀번호가 틀립니다.");
+    //     }
+    //
+    //     if (updateScheduleRequest.content() == null && updateScheduleRequest.name() == null) {
+    //         throw new BadRequestException("수정할 내용이 없습니다.");
+    //     }
+    //
+    //     schedule.update(
+    //         updateScheduleRequest.content() != null ? updateScheduleRequest.content() : schedule.getContent(),
+    //         updateScheduleRequest.name() != null ? updateScheduleRequest.name() : schedule.getName()
+    //     );
+    //
+    //     int affectedRow = scheduleRepository.update(schedule);
+    //
+    //     if (affectedRow != 1) {
+    //         throw new BadRequestException("일정 수정을 실패했습니다.");
+    //     }
+    //
+    //     return new UpdateScheduleResponse(
+    //         schedule.getContent(),
+    //         schedule.getName(),
+    //         schedule.getModifiedAt()
+    //     );
+    // }
+//
+//     @Transactional
+//     public DeleteScheduleResponse delete(Long id, String password) {
+//         Schedule schedule = scheduleRepository.findById(id);
+//
+//         if (password == null || password.isEmpty() || !schedule.getPassword().equals(password)) {
+//             throw new BadRequestException("비밀번호가 틀립니다.");
+//         }
+//
+//         int affectedRow = scheduleRepository.delete(id);
+//
+//         if (affectedRow != 1) {
+//             throw new BadRequestException("일정 삭제를 실패했습니다.");
+//         }
+//
+//         return new DeleteScheduleResponse(id);
+//     }
 }

--- a/src/main/java/com/doorcs/schedule/service/UserService.java
+++ b/src/main/java/com/doorcs/schedule/service/UserService.java
@@ -1,0 +1,42 @@
+package com.doorcs.schedule.service;
+
+import java.sql.Date;
+
+import org.springframework.stereotype.Service;
+
+import com.doorcs.schedule.domain.User;
+import com.doorcs.schedule.domain.UserRepository;
+import com.doorcs.schedule.exception.BadRequestException;
+import com.doorcs.schedule.service.request.CreateUserRequest;
+import com.doorcs.schedule.service.response.CreateUserResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public CreateUserResponse create(CreateUserRequest createUserRequest) {
+        Date createdAt = new Date(System.currentTimeMillis());
+
+        int affectedRow = userRepository.save(User.of(
+                createUserRequest.name(),
+                createUserRequest.password(),
+                createUserRequest.email(),
+                createdAt // 입력으로 유저 생성 날짜를 받는건 뭔가 이상하다. 이건 시스템에서 관리하는게 맞는 것 같다.
+            )
+        );
+
+        if (affectedRow != 1) {
+            throw new BadRequestException("사용자 생성에 실패했습니다.");
+        }
+
+        return new CreateUserResponse(
+            createUserRequest.name(),
+            createUserRequest.email(),
+            createdAt
+        );
+    }
+}

--- a/src/main/java/com/doorcs/schedule/service/UserService.java
+++ b/src/main/java/com/doorcs/schedule/service/UserService.java
@@ -13,6 +13,7 @@ import com.doorcs.schedule.service.request.CreateUserRequest;
 import com.doorcs.schedule.service.request.SigninRequest;
 import com.doorcs.schedule.service.request.UpdateUserRequest;
 import com.doorcs.schedule.service.response.CreateUserResponse;
+import com.doorcs.schedule.service.response.DeleteUserResponse;
 import com.doorcs.schedule.service.response.SigninResponse;
 import com.doorcs.schedule.service.response.UpdateUserResponse;
 
@@ -86,5 +87,23 @@ public class UserService {
             user.getEmail(),
             user.getModifiedAt()
         );
+    }
+
+    @Transactional
+    public DeleteUserResponse delete(String jwt, String password) {
+        Long userId = jwtUtil.getUserId(jwt);
+        User user = userRepository.findById(userId);
+
+        if (password == null || password.isEmpty() || !user.getPassword().equals(password)) {
+            throw new BadRequestException("비밀번호가 틀립니다.");
+        }
+
+        int affectedRow = userRepository.delete(userId);
+
+        if (affectedRow != 1) {
+            throw new BadRequestException("사용자 삭제에 실패했습니다.");
+        }
+
+        return new DeleteUserResponse(userId);
     }
 }

--- a/src/main/java/com/doorcs/schedule/service/UserService.java
+++ b/src/main/java/com/doorcs/schedule/service/UserService.java
@@ -11,8 +11,10 @@ import com.doorcs.schedule.exception.BadRequestException;
 import com.doorcs.schedule.jwt.JwtUtil;
 import com.doorcs.schedule.service.request.CreateUserRequest;
 import com.doorcs.schedule.service.request.SigninRequest;
+import com.doorcs.schedule.service.request.UpdateUserRequest;
 import com.doorcs.schedule.service.response.CreateUserResponse;
 import com.doorcs.schedule.service.response.SigninResponse;
+import com.doorcs.schedule.service.response.UpdateUserResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -56,6 +58,33 @@ public class UserService {
 
         return new SigninResponse(
             jwtUtil.createJwt(user.getId())
+        );
+    }
+
+    @Transactional
+    public UpdateUserResponse update(String jwt, UpdateUserRequest updateUserRequest) {
+        User user = userRepository.findById(jwtUtil.getUserId(jwt));
+
+        if (user == null) {
+            throw new BadRequestException("로그인이 필요합니다.");
+        }
+
+        user.update(
+            updateUserRequest.name() == null ? user.getName() : updateUserRequest.name(),
+            updateUserRequest.password() == null ? user.getPassword() : updateUserRequest.password(),
+            updateUserRequest.email() == null ? user.getEmail() : updateUserRequest.email()
+        );
+
+        int affectedRow = userRepository.update(user);
+
+        if (affectedRow != 1) {
+            throw new BadRequestException("사용자 정보 수정에 실패했습니다.");
+        }
+
+        return new UpdateUserResponse(
+            user.getName(),
+            user.getEmail(),
+            user.getModifiedAt()
         );
     }
 }

--- a/src/main/java/com/doorcs/schedule/service/request/CreateScheduleRequest.java
+++ b/src/main/java/com/doorcs/schedule/service/request/CreateScheduleRequest.java
@@ -1,6 +1,4 @@
 package com.doorcs.schedule.service.request;
 
-import java.sql.Date;
-
-public record CreateScheduleRequest(String content, String name, String password, Date date) {
+public record CreateScheduleRequest(String content) {
 }

--- a/src/main/java/com/doorcs/schedule/service/request/CreateUserRequest.java
+++ b/src/main/java/com/doorcs/schedule/service/request/CreateUserRequest.java
@@ -1,0 +1,4 @@
+package com.doorcs.schedule.service.request;
+
+public record CreateUserRequest(String name, String password, String email) {
+}

--- a/src/main/java/com/doorcs/schedule/service/request/DeleteScheduleRequest.java
+++ b/src/main/java/com/doorcs/schedule/service/request/DeleteScheduleRequest.java
@@ -1,4 +1,0 @@
-package com.doorcs.schedule.service.request;
-
-public record DeleteScheduleRequest(String password) {
-}

--- a/src/main/java/com/doorcs/schedule/service/request/DeleteUserRequest.java
+++ b/src/main/java/com/doorcs/schedule/service/request/DeleteUserRequest.java
@@ -1,0 +1,4 @@
+package com.doorcs.schedule.service.request;
+
+public record DeleteUserRequest(String password) {
+}

--- a/src/main/java/com/doorcs/schedule/service/request/SigninRequest.java
+++ b/src/main/java/com/doorcs/schedule/service/request/SigninRequest.java
@@ -1,0 +1,4 @@
+package com.doorcs.schedule.service.request;
+
+public record SigninRequest(String email, String password) { // email 필드가 UNIQUE이므로 email, pw 사용
+}

--- a/src/main/java/com/doorcs/schedule/service/request/UpdateScheduleRequest.java
+++ b/src/main/java/com/doorcs/schedule/service/request/UpdateScheduleRequest.java
@@ -1,4 +1,4 @@
 package com.doorcs.schedule.service.request;
 
-public record UpdateScheduleRequest(String content, String name, String password) {
+public record UpdateScheduleRequest(String content) {
 }

--- a/src/main/java/com/doorcs/schedule/service/request/UpdateUserRequest.java
+++ b/src/main/java/com/doorcs/schedule/service/request/UpdateUserRequest.java
@@ -1,0 +1,4 @@
+package com.doorcs.schedule.service.request;
+
+public record UpdateUserRequest(String name, String password, String email) {
+}

--- a/src/main/java/com/doorcs/schedule/service/response/CreateScheduleResponse.java
+++ b/src/main/java/com/doorcs/schedule/service/response/CreateScheduleResponse.java
@@ -2,5 +2,5 @@ package com.doorcs.schedule.service.response;
 
 import java.sql.Date;
 
-public record CreateScheduleResponse(String content, String name, Date createdDate) {
+public record CreateScheduleResponse(Long userId, String content, Date createdDate) {
 }

--- a/src/main/java/com/doorcs/schedule/service/response/CreateUserResponse.java
+++ b/src/main/java/com/doorcs/schedule/service/response/CreateUserResponse.java
@@ -1,0 +1,6 @@
+package com.doorcs.schedule.service.response;
+
+import java.sql.Date;
+
+public record CreateUserResponse(String name, String email, Date createdDate) {
+}

--- a/src/main/java/com/doorcs/schedule/service/response/DeleteScheduleResponse.java
+++ b/src/main/java/com/doorcs/schedule/service/response/DeleteScheduleResponse.java
@@ -1,4 +1,4 @@
 package com.doorcs.schedule.service.response;
 
-public record DeleteScheduleResponse(Long deletedScheduleId) {
+public record DeleteScheduleResponse(Long deletedScheduleId, String content) {
 }

--- a/src/main/java/com/doorcs/schedule/service/response/DeleteUserResponse.java
+++ b/src/main/java/com/doorcs/schedule/service/response/DeleteUserResponse.java
@@ -1,0 +1,4 @@
+package com.doorcs.schedule.service.response;
+
+public record DeleteUserResponse(Long deletedUserId) {
+}

--- a/src/main/java/com/doorcs/schedule/service/response/SigninResponse.java
+++ b/src/main/java/com/doorcs/schedule/service/response/SigninResponse.java
@@ -1,0 +1,4 @@
+package com.doorcs.schedule.service.response;
+
+public record SigninResponse(String jwt) {
+}

--- a/src/main/java/com/doorcs/schedule/service/response/SignoutResponse.java
+++ b/src/main/java/com/doorcs/schedule/service/response/SignoutResponse.java
@@ -1,0 +1,4 @@
+package com.doorcs.schedule.service.response;
+
+public record SignoutResponse(String message) {
+}

--- a/src/main/java/com/doorcs/schedule/service/response/UpdateScheduleResponse.java
+++ b/src/main/java/com/doorcs/schedule/service/response/UpdateScheduleResponse.java
@@ -2,5 +2,5 @@ package com.doorcs.schedule.service.response;
 
 import java.sql.Date;
 
-public record UpdateScheduleResponse(String content, String name, Date modifiedAt) {
+public record UpdateScheduleResponse(String content, Date modifiedDate) {
 }

--- a/src/main/java/com/doorcs/schedule/service/response/UpdateUserResponse.java
+++ b/src/main/java/com/doorcs/schedule/service/response/UpdateUserResponse.java
@@ -1,0 +1,6 @@
+package com.doorcs.schedule.service.response;
+
+import java.sql.Date;
+
+public record UpdateUserResponse(String name, String email, Date modifiedDate) {
+}


### PR DESCRIPTION
## Lv.3 연관 관계 설정

- [x] 작성자와 일정의 연결
  - 설명
    - 동명이인의 작성자가 있어 어떤 작성자가 등록한 ‘할 일’인지 구별할 수 없음
    - 작성자를 식별하기 위해 이름으로만 관리하던 작성자에게 고유 식별자를 부여합니다.
    - 작성자를 할 일과 분리해서 관리합니다.
    - 작성자 테이블을 생성하고 일정 테이블에 FK를 생성해 연관관계를 설정해 봅니다.
  - 조건
    - 작성자는 이름 외에 이메일, 등록일, 수정일 정보를 가지고 있습니다.
      - 작성자의 정보는 추가로 받을 수 있습니다.(조건만 만족한다면 다른 데이터 추가 가능)
    - 작성자의 고유 식별자를 통해 일정이 검색이 될 수 있도록 전체 일정 조회 코드 수정.
    - 작성자의 고유 식별자가 일정 테이블의 외래키가 될 수 있도록 합니다.