### PR TITLE
refactor: 페이지네이션 기능 구현

### DIFF
--- a/src/main/java/com/doorcs/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/doorcs/schedule/controller/ScheduleController.java
@@ -45,9 +45,11 @@ public class ScheduleController {
     @GetMapping("/schedules")
     public ResponseEntity<List<ReadScheduleResponse>> getAll(
         @RequestParam(required = false) Long userId,
-        @RequestParam(required = false) Date modifiedDate
+        @RequestParam(required = false) Date modifiedDate,
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "5", name="pagesize") int pageSize
     ) {
-        List<ReadScheduleResponse> readScheduleResponses = scheduleService.getAll(userId, modifiedDate);
+        List<ReadScheduleResponse> readScheduleResponses = scheduleService.getAll(userId, modifiedDate, page, pageSize);
 
         return ResponseEntity.ok().body(readScheduleResponses);
     }

--- a/src/main/java/com/doorcs/schedule/domain/ScheduleRepository.java
+++ b/src/main/java/com/doorcs/schedule/domain/ScheduleRepository.java
@@ -28,7 +28,7 @@ public class ScheduleRepository {
         );
     }
 
-    public List<Schedule> findAll(Long userId, Date date) {
+    public List<Schedule> findAll(Long userId, Date date, int page, int pageSize) {
         String sql = "SELECT * FROM schedule WHERE TRUE";
         List<Object> params = new ArrayList<>();
 
@@ -42,7 +42,9 @@ public class ScheduleRepository {
             params.add(date);
         }
 
-        sql += " ORDER BY modified_at";
+        sql += " ORDER BY modified_at LIMIT ? OFFSET ?";
+        params.add(pageSize);
+        params.add(page * pageSize);
 
         return jdbcTemplate.query(sql, (rs, rowNum) -> Schedule.of(
                 rs.getLong("id"),

--- a/src/main/java/com/doorcs/schedule/service/ScheduleService.java
+++ b/src/main/java/com/doorcs/schedule/service/ScheduleService.java
@@ -55,8 +55,8 @@ public class ScheduleService {
     }
 
     @Transactional(readOnly = true)
-    public List<ReadScheduleResponse> getAll(Long userId, Date date) {
-        return scheduleRepository.findAll(userId, date).stream()
+    public List<ReadScheduleResponse> getAll(Long userId, Date date, int page, int pageSize) {
+        return scheduleRepository.findAll(userId, date, page, pageSize).stream()
             .map(schedule -> {
                 User user = userRepository.findById(schedule.getUserId());
                 String userName = user != null ? user.getName() : "탈퇴한 사용자";


### PR DESCRIPTION
## Lv.4 페이지네이션

- 설명
  - 많은 양의 데이터를 효율적으로 표시하기 위해 데이터를 여러 페이지로 나눕니다.
    - 페이지 번호와 페이지 크기를 쿼리 파라미터로 전달하여 요청하는 항목을 나타냅니다.
    - 전달받은 페이지 번호와 크기를 기준으로 쿼리를 작성하여 필요한 데이터만을 조회하고 반환
- 조건
  - [x] 등록된 일정 목록을 페이지 번호와 크기를 기준으로 모두 조회
  - [x] 조회한 일정 목록에는 작성자 이름이 포함
  - [x] 범위를 넘어선 페이지를 요청하는 경우 빈 배열을 반환
  - [ ] ~~페이징 객체를 활용할 수 있음~~
    - Pageable 객체와 `pageable.getPageSize()`, `pageable.getOffset()` 메서드에 대해 공부하였지만,
    Pageable 객체를 뜯어서 값을 가져와 사용하는 것은 바람직하지 않은 방향이라 판단하여
    `int page`, `int pageSize`를 `@PathVariable`로 받아 처리하였습니다.
    - [x] 페이지 크기, 페이지 번호를 통해 페이징을 구현함